### PR TITLE
Toggles are not wonking anymore 😢 

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -19,7 +19,7 @@ export const Dashboard: React.FC = () => {
               if (existing) {
                 return existing;
               }
-              return condition;
+              return structuredClone(condition);
             })
           }
         };

--- a/src/components/Verifications.tsx
+++ b/src/components/Verifications.tsx
@@ -8,8 +8,6 @@ interface Props {
 
 export const Verifications: React.FC<Props> = ({verifications, onChange}) => {
   const handleChange = (vIndex: number, cIndex: number, value: boolean) => {
-    const v = structuredClone(verifications);
-
     /**
      * Hint
      *
@@ -20,8 +18,8 @@ export const Verifications: React.FC<Props> = ({verifications, onChange}) => {
      * const v = JSON.parse(JSON.stringify(verifications));
      */
 
-    v[vIndex].eligibility.checks[cIndex].passed = value;
-    onChange(v);
+    verifications[vIndex].eligibility.checks[cIndex].passed = value;
+    onChange(verifications);
   };
 
   return (


### PR DESCRIPTION
Due to our process of overriding candidate data during verification, arise a peculiar issue with toggle behavior. Here’s a breakdown of the journey to discovery and solution:

Initially, on fetching the candidate data (getCandidate), we initialize a candidate object in memory, which contains an array of verifications, each with a size of 2.
We maintain the state of the candidate within a useEffect for reconciliation purposes. Within this function, we perform a check to see if the reference object matches the current candidate object. If they match, we return the same object initialized in memory beforehand.
However, we observed anomalous behavior in cases where the data differed, specifically in the humor and license fields. Here, the reference object was being passed by reference, resulting in:
For the system, humor and license fields point to the same object in memory, while experience and car are unique to the candidate.
For the interview, all fields except for car point to the same object in memory.
This leads to the unexpected toggle behavior, as the humor and license fields reference the same object in memory.

Attempts to use structured clone and deep clone methods were unsuccessful. These methods still treated humor and license as a single cloned entity, maintaining their reference in memory. Conversely, serializing the entire object via JSON.stringify, and then parsing it back with JSON.parse, effectively resolves the issue. This process creates distinct memory references for humor and license, thereby eliminating the buggy behavior.

The structured clone operation stores references of all objects internally in a map. Upon cloning each object, it consults this map to assign references to the newly cloned objects. However, in our scenario, since humor and license share the same reference in both the system and interview contexts, the cloning process inadvertently points both to the same cloned object, as it would in the original.

It was fixed by deep cloning the particular candidate data to make a new copy of it